### PR TITLE
examples: bug fix

### DIFF
--- a/examples/rknn_yolov5_demo/src/postprocess.cc
+++ b/examples/rknn_yolov5_demo/src/postprocess.cc
@@ -109,13 +109,13 @@ static int nms(int validCount, std::vector<float>& outputLocations, std::vector<
                int filterId, float threshold)
 {
   for (int i = 0; i < validCount; ++i) {
-    if (order[i] == -1 || classIds[i] != filterId) {
+    int n = order[i];
+    if (order[i] == -1 || classIds[n] != filterId) {
       continue;
     }
-    int n = order[i];
     for (int j = i + 1; j < validCount; ++j) {
       int m = order[j];
-      if (m == -1 || classIds[i] != filterId) {
+      if (m == -1 || classIds[m] != filterId) {
         continue;
       }
       float xmin0 = outputLocations[n * 4 + 0];


### PR DESCRIPTION
由于order[i]是已经排序过，classIds[i]是没有排序的，这里与filterId做对比是不正确的。